### PR TITLE
OS-48: Limit the number of sitemaps processed per depth

### DIFF
--- a/backend/routes/api.py
+++ b/backend/routes/api.py
@@ -56,6 +56,7 @@ def start_scrape():
         max_pages = data.get("max_pages")  # Allow None
         use_tor = data.get("use_tor")  # Allow None
         headless = data.get("headless")  # Allow None
+        sitemap_limit = data.get("sitemap_limit", 10) # default to 10
 
         job_id = str(uuid.uuid4())
         step_id = "email_scrape"
@@ -67,7 +68,7 @@ def start_scrape():
         def scrape_task():
             try:
                 logging.info(f"Starting scrape job {job_id} for URL: {url}")
-                emails = scrape_emails(job_id, step_id, url, max_pages=max_pages, use_tor=use_tor, headless=headless)
+                emails = scrape_emails(job_id, step_id, url, max_pages=max_pages, use_tor=use_tor, headless=headless, sitemap_limit=sitemap_limit)
 
                 # Prepare the result dictionary
                 result = {"job_id": job_id, "input": url, "emails": emails}

--- a/backend/scripts/scraping/scrape_for_email.py
+++ b/backend/scripts/scraping/scrape_for_email.py
@@ -55,7 +55,7 @@ def sort_urls_by_email_likelihood(urls):
     logging.info(f"Sorted {len(sorted_urls)} URLs by email likelihood")
     return sorted_urls
 
-def scrape_emails(job_id, step_id, base_url, max_pages=10, use_tor=False, headless=False):
+def scrape_emails(job_id, step_id, base_url, max_pages=10, use_tor=False, headless=False, sitemap_limit=10):
     """
     Orchestrate email scraping from a website using sitemaps and WebDriver.
     
@@ -65,6 +65,7 @@ def scrape_emails(job_id, step_id, base_url, max_pages=10, use_tor=False, headle
         max_pages (int): Maximum number of pages to scrape.
         use_tor (bool): Whether to use Tor for WebDriver setup.
         headless (bool): Whether to run WebDriver in headless mode.
+        sitemap_limit (int): Maximum number of sitemaps to process per depth.
     
     Returns:
         list: List of unique email addresses found.
@@ -92,7 +93,7 @@ def scrape_emails(job_id, step_id, base_url, max_pages=10, use_tor=False, headle
     
     # Discover URLs from sitemap files
     for sitemap_url in sitemap_urls:
-        urls_from_sitemap = get_urls_from_sitemap(driver, sitemap_url)
+        urls_from_sitemap = get_urls_from_sitemap(driver, sitemap_url, sitemap_limit=sitemap_limit)
         logging.info(f"URLs from sitemap {sitemap_url}: {urls_from_sitemap}")
         urls_to_visit.extend(urls_from_sitemap)
     


### PR DESCRIPTION
Introduces a `sitemap_limit` parameter to control the number of sitemaps processed at each depth during sitemap parsing. This helps to prevent performance issues when encountering websites with very large sitemaps.

The limit is exposed as a parameter in the `/scrape/website-emails` API endpoint, with a default value of 10. This parameter is then propagated down through the call stack to the sitemap parsing functions where it is applied.